### PR TITLE
Fix comment typo in learning page

### DIFF
--- a/pages/learning.tsx
+++ b/pages/learning.tsx
@@ -22,7 +22,7 @@ type SessionData = {
 };
 
  const fetchSession = async (userId: string): Promise<SessionData> => {
-   // Next.js（3000）ではなく NestJS（3001）を直接叩る
+   // Next.js（3000）ではなく NestJS（3001）を直接叩く
    const res = await axios.post(
      'http://localhost:3001/session/start',
      { userId },


### PR DESCRIPTION
## Summary
- correct a typo in `pages/learning.tsx`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846ad277abc832094cffdc63e3df9c8