### PR TITLE
Add Jest config and calibrator test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build:backend": "nest build",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "start": "nest start",
     "start:dev:backend": "ts-node-dev --respawn --transpile-only  --require reflect-metadata --require tsconfig-paths/register src/main.ts",
     "build": "nest build",
@@ -44,6 +44,15 @@
     "prisma": "^6.6.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "roots": [
+      "<rootDir>/tests"
+    ]
   }
 }

--- a/tests/difficulty.calibrator.spec.ts
+++ b/tests/difficulty.calibrator.spec.ts
@@ -1,0 +1,10 @@
+import { DifficultyCalibrator } from '../src/content/difficulty.calibrator';
+
+describe('DifficultyCalibrator', () => {
+  it('calibrate(1200) returns a value between 100 and 1300', () => {
+    const calibrator = new DifficultyCalibrator();
+    const result = calibrator.calibrate(1200);
+    expect(result).toBeGreaterThanOrEqual(100);
+    expect(result).toBeLessThanOrEqual(1300);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Jest with `ts-jest`
- add test script
- create difficulty calibrator unit test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ade2477483208cc1acc77387dfca